### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/ll/linked_list.rs
+++ b/src/ll/linked_list.rs
@@ -47,12 +47,12 @@ impl<T> LinkedList<T> {
         let mut node = Node::new(element);
         unsafe {
             node.as_mut().next = None;
+        }
 
             match self.tail {
-                Some(mut tail) => tail.as_mut().next = Some(node),
+                Some(mut tail) => unsafe { tail.as_mut().next = Some(node) }, 
                 None => self.head = Some(node),
             }
-        }
 
         self.tail = Some(node);
         self.len += 1;
@@ -133,9 +133,9 @@ impl<'a, T> Iterator for Iter<'a, T> {
         if self.len == 0 {
             None
         } else {
-            self.head.map(|node| unsafe {
+            self.head.map(|node| {
                 // Need an unbound lifetime to get 'a
-                let node = &*node.as_ptr();
+                let node = unsafe { &*node.as_ptr() };
                 self.len -= 1;
                 self.head = node.next;
                 &node.element

--- a/src/tree/binary/builder/level.rs
+++ b/src/tree/binary/builder/level.rs
@@ -43,9 +43,9 @@ fn build<K: std::str::FromStr, V>(vec: &[&str]) -> Tree<K, V> {
         }
 
         if let Some(mut node) = node {
+            let parent = binary_tree::parent(i);
+            let mut parent_node = aux[parent].unwrap();
             unsafe {
-                let parent = binary_tree::parent(i);
-                let mut parent_node = aux[parent].unwrap();
                 node.as_mut().parent = Some(parent_node);
                 if binary_tree::left(parent) == i {
                     parent_node.as_mut().left = Some(node);

--- a/src/tree/binary/node.rs
+++ b/src/tree/binary/node.rs
@@ -134,27 +134,27 @@ impl<'a, K: 'a, V: 'a> NodeQuery<K, V> {
     }
 
     pub fn set_left(&mut self, node: Option<NonNull<Node<K, V>>>) {
-        unsafe {
+       
             if let Some(mut p) = self.node {
-                p.as_mut().left = node;
+                unsafe { p.as_mut().left = node };
             }
 
             if let Some(mut p) = node {
-                p.as_mut().parent = self.node;
+                unsafe { p.as_mut().parent = self.node };
             }
-        }
+        
     }
 
     pub fn set_right(&mut self, node: Option<NonNull<Node<K, V>>>) {
-        unsafe {
+        
             if let Some(mut p) = self.node {
-                p.as_mut().right = node;
+                unsafe { p.as_mut().right = node };
             }
 
             if let Some(mut p) = node {
-                p.as_mut().parent = self.node;
+                unsafe { p.as_mut().parent = self.node };
             }
-        }
+        
     }
 
     pub fn set_children(&mut self, l: Option<NonNull<Node<K, V>>>, r: Option<NonNull<Node<K, V>>>) {

--- a/src/tree/binary/tree.rs
+++ b/src/tree/binary/tree.rs
@@ -47,9 +47,9 @@ impl<K, V> Drop for Tree<K, V> {
 }
 
 fn height<K, V>(node: Option<NonNull<Node<K, V>>>) -> usize {
-    node.map_or(0, |node| unsafe {
-        let lh = height(node.as_ref().left);
-        let rh = height(node.as_ref().right);
+    node.map_or(0, |node| {
+        let lh = height(unsafe { node.as_ref().left });
+        let rh = height(unsafe { node.as_ref().right });
         1 + std::cmp::max(lh, rh)
     })
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for many safe expressions. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 